### PR TITLE
add radio buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitodl/mdl-react-components",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "React component implementations for material library",
   "scripts": {
     "test": "./scripts/test/js_test.sh",
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@material/button": "^0.26.0",
     "@material/dialog": "^0.26.0",
+    "@material/radio": "^0.30.0",
     "ava": "^0.24.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "7.2.3",
@@ -70,11 +71,13 @@
     "react-dom": "^15.6.0",
     "react-test-renderer": "^15.6.0",
     "rollup": "^0.52.1",
-    "rollup-plugin-babel": "^3.0.2"
+    "rollup-plugin-babel": "^3.0.2",
+    "sinon": "^4.3.0"
   },
   "peerDependencies": {
     "@material/button": "^0.26.0",
     "@material/dialog": "^0.26.0",
+    "@material/radio": "^0.30.0",
     "react": "^15.6.0",
     "react-dom": "^15.6.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,6 +26,7 @@ const sources = [
   'index.js',
   'Button.js',
   'Dialog.js',
+  'Radio.js',
 ]
 
 const config = sources.map((source) => ({

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -1,0 +1,53 @@
+// @flow
+import React from "react"
+
+type RadioOption = {
+  value: any,
+  label: string
+}
+
+type RadioProps = {
+  name: string,
+  className?: string,
+  options: Array<RadioOption>,
+  onChange: Function,
+  value: any
+}
+
+export default class Radio extends React.Component<RadioProps, *> {
+  renderOptions = ({ value, label }: RadioOption, idx: number) => {
+    const { name, onChange } = this.props
+    const currentValue = this.props.value
+
+    return (
+      <div key={idx}>
+        <div className="mdc-radio">
+          <input
+            className="mdc-radio__native-control"
+            type="radio"
+            id={`radio-${idx}`}
+            name={name}
+            value={value}
+            checked={value === currentValue}
+            onChange={onChange}
+          />
+          <div className="mdc-radio__background">
+            <div className="mdc-radio__outer-circle" />
+            <div className="mdc-radio__inner-circle" />
+          </div>
+        </div>
+        <label id={`radio-${idx}-label`} htmlFor={`radio-${idx}`}>
+          {label}
+        </label>
+      </div>
+    )
+  }
+
+  render() {
+    const { className, options } = this.props
+
+    return (
+      <div className={className || ""}>{options.map(this.renderOptions)}</div>
+    )
+  }
+}

--- a/src/Radio_test.js
+++ b/src/Radio_test.js
@@ -1,0 +1,76 @@
+import React from "react"
+import test from "ava"
+import { mount } from "enzyme"
+import sinon from "sinon"
+
+import Radio from "./Radio"
+
+const options = [
+  { value: "first", label: "First" },
+  { value: "second", label: "Second" }
+]
+
+const renderRadio = (props = {}) =>
+  mount(
+    <Radio
+      onChange={onChangeStub}
+      name="radiotest"
+      options={options}
+      {...props}
+    />
+  )
+
+let onChangeStub
+
+test.beforeEach(() => {
+  onChangeStub = sinon.stub()
+})
+
+test("Radio should render the options", t => {
+  const wrapper = renderRadio()
+  t.true(wrapper.exists())
+
+  wrapper.find("input").forEach((wrapper, idx) => {
+    const { name, value } = wrapper.props()
+    t.is(name, "radiotest")
+    t.is(value, options[idx].value)
+  })
+  wrapper.find("label").forEach((wrapper, idx) => {
+    t.is(wrapper.text(), options[idx].label)
+  })
+})
+
+test("Radio should render a className if passed in", t => {
+  const wrapper = renderRadio({
+    className: "weeee"
+  })
+
+  t.is(
+    wrapper
+      .find("div")
+      .at(0)
+      .props().className,
+    "weeee"
+  )
+})
+
+test("Radio should call onChange func on click", t => {
+  const wrapper = renderRadio()
+  const event = {
+    target: { value: "first" }
+  }
+  wrapper
+    .find("input")
+    .at(1)
+    .simulate("change", event)
+  t.true(onChangeStub.called)
+})
+
+test("Radio should have the input checked for the value prop", t => {
+  const wrapper = renderRadio({
+    value: "second"
+  })
+  const [first, second] = wrapper.find("input")
+  t.false(first.props.checked)
+  t.true(second.props.checked)
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { default as Button } from "./Button"
 export { default as Dialog } from "./Dialog"
+export { default as Radio } from "./Radio"

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,10 @@
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/@material/base/-/base-0.24.0.tgz#888a61e5b6580e35a66384a9f8823091b4fe7c55"
 
+"@material/base@^0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-0.29.0.tgz#5fac94c45907e38c969130e959722288d4ce06b2"
+
 "@material/button@^0.26.0":
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/@material/button/-/button-0.26.0.tgz#d222ecbcfde5a5e0923aeb6b69acedba0f830c8e"
@@ -81,6 +85,16 @@
     "@material/animation" "^0.25.0"
     "@material/theme" "^0.4.0"
 
+"@material/radio@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-0.30.0.tgz#3bb84ba7016738a5d0d567c70514deb887ece5c2"
+  dependencies:
+    "@material/animation" "^0.25.0"
+    "@material/base" "^0.29.0"
+    "@material/ripple" "^0.30.0"
+    "@material/selection-control" "^0.30.0"
+    "@material/theme" "^0.30.0"
+
 "@material/ripple@^0.26.0":
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.26.0.tgz#84310fe3ecf9878e4999d6fb553f639402146114"
@@ -88,13 +102,30 @@
     "@material/base" "^0.24.0"
     "@material/theme" "^0.25.0"
 
+"@material/ripple@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.30.0.tgz#99b30801c5784b6bcc1ff702e4dcdae49ace813e"
+  dependencies:
+    "@material/base" "^0.29.0"
+    "@material/theme" "^0.30.0"
+
 "@material/rtl@^0.1.8":
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.1.8.tgz#2462db15e2d4e041666485559c028382872b01fb"
 
+"@material/selection-control@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@material/selection-control/-/selection-control-0.30.0.tgz#80f2230ce9a8ea8cd9a7f1a853e8179ca0a72de1"
+  dependencies:
+    "@material/ripple" "^0.30.0"
+
 "@material/theme@^0.25.0":
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.25.0.tgz#707b4c61ebc62e662d36164c8dd45fcf98bb1444"
+
+"@material/theme@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.30.0.tgz#503d7fd5ac88ff70763bb277236ee7188982e5d2"
 
 "@material/theme@^0.4.0":
   version "0.4.0"
@@ -107,6 +138,12 @@
 "@material/typography@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.3.0.tgz#f828c2d3215bfd66c58072709b4260c64125390a"
+
+"@sinonjs/formatio@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  dependencies:
+    samsam "1.3.0"
 
 "@types/node@*":
   version "8.0.56"
@@ -1716,6 +1753,10 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
+diff@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
@@ -2541,6 +2582,10 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-symbol-support-x@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz#66ec2e377e0c7d7ccedb07a3a84d77510ff1bc4c"
@@ -3138,6 +3183,10 @@ jsx-ast-utils@^2.0.0:
   dependencies:
     array-includes "^3.0.3"
 
+just-extend@^1.1.27:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -3237,6 +3286,10 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -3271,6 +3324,10 @@ loglevel-colored-level-prefix@^1.0.0:
 loglevel@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.0.tgz#ae0caa561111498c5ba13723d6fb631d24003934"
+
+lolex@^2.2.0, lolex@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3502,6 +3559,16 @@ nearley@^2.7.10:
     nomnom "~1.6.2"
     railroad-diagrams "^1.0.0"
     randexp "^0.4.2"
+
+nise@^1.2.0:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.2.5.tgz#a143371b65014b6807d3a6e6b4556063f3a53363"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    just-extend "^1.1.27"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -3847,6 +3914,12 @@ path-key@^2.0.0:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -4469,6 +4542,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
 sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -4508,6 +4585,18 @@ shebang-regex@^1.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.3.0.tgz#cec9b27d5f4e2c63c1a79c9dc1c05d34bb088234"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    diff "^3.1.0"
+    lodash.get "^4.4.2"
+    lolex "^2.2.0"
+    nise "^1.2.0"
+    supports-color "^5.1.0"
+    type-detect "^4.0.5"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -4721,6 +4810,12 @@ supports-color@^5.0.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
 symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
@@ -4788,6 +4883,10 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
@@ -4878,6 +4977,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
This adds the material radio buttons to our package.

If you want to test it out manually, I have a branch in `open-discussions` which is set up for testing it (I will change that branch to just add the new version of the package and the peer dependency once this merges).

Do this:

- navigate to open-discussions and checkout the `ap/add-radio-butotn` branch (yes I misspelled it, haha)
- checkout this branch and run `npm pack`
- copy the resulting `.tgz` file to your open-discussions directory
- run `docker-compose run watch yarn add ./foobar.tgz` (you may need to delete your `node_modules` first)

Ok, so then you should have the code from this branch installed over my open-discussions branch. I added the `<Radio />` component to the channel creation form, so if you visit `/manage/channel/new` you should see the material radio buttons. You should be able to switch between them, and they should look snazzy and so on.